### PR TITLE
Increase maxdepth for activate file search

### DIFF
--- a/lib/virtualenv-manager.coffee
+++ b/lib/virtualenv-manager.coffee
@@ -67,7 +67,7 @@ module.exports =
           if process.platform == 'win32'
             cmd = 'dir /s /b activate.bat'
           else
-            cmd = 'find "$(pwd - P)" -follow -maxdepth 3 -name "activate"'
+            cmd = 'find "$(pwd - P)" -follow -maxdepth 4 -name "activate"'
 
           exec cmd, {'cwd' : filePath}, (error, stdout, stderr) =>
             if stdout


### PR DESCRIPTION
I increased the maxdepth for the activate file search for compatibility with some other tools. For example, the virtualenvs created by direnv are a bit more nested than expected: they are put in `.direnv/python-3.6.8/bin/activate`